### PR TITLE
Adding auto-approval for myself

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto approve
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'dooplan'
+    steps:
+      - uses: hmarr/auto-approve-action@v3


### PR DESCRIPTION
Since I'm the only one working on this project still, I don't want to deal with approving my own PR's.
However, I do want to protect the main branch from writing, and don't want the owner account to straight up ignore this restriction.